### PR TITLE
Test power flow against MATPOWER using Oct2Py

### DIFF
--- a/andes/test/test_matpower.py
+++ b/andes/test/test_matpower.py
@@ -1,0 +1,37 @@
+
+import unittest
+import logging
+
+from oct2py import Oct2Py
+from andes.main import run
+
+VM = 7
+VA = 8
+
+
+class TestMATPOWER(unittest.TestCase):
+
+    def setUp(self):
+        self.mp = Oct2Py(logger=logging.getLogger())
+
+        self.opts = self.mp.mpoption("pf.alg", "NR", "verbose", 0, "out.all", 0)
+
+    def testPowerFlow(self):
+        for name in ["case9"]:
+            mpc = self.mp.loadcase(name)
+            out = self.mp.runpf(mpc, self.opts)
+
+            mpVm = out.bus[:, VM]
+            mpVa = out.bus[:, VA]
+
+            system = run("/usr/local/matpower/data/" + name + ".m", routine=["pflow"])
+
+            idx, names, Vm, Va, Pg, Qg, Pl, Ql = system.get_busdata()
+
+            for i in range(len(mpVm)):
+                self.assertAlmostEqual(Vm[i], mpVm[i], msg="{} - Vm[{}]".format(name, i))
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    unittest.main()

--- a/matpower.dockerfile
+++ b/matpower.dockerfile
@@ -1,0 +1,9 @@
+FROM rlincoln/oct2pypower
+
+RUN pip3 install texttable cvxopt
+
+ADD . /usr/src/andes
+#RUN cd /usr/src/andes && python3 setup.py install
+ENV PYTHONPATH /usr/src/andes
+
+ENTRYPOINT ["python3", "-m", "andes.test.test_matpower"]


### PR DESCRIPTION
I have been experimenting with using [Oct2Py](https://blink1073.github.io/oct2py/) to call [MATPOWER](https://github.com/MATPOWER/matpower/) functions from Python:

https://github.com/rwl/oct2pypower

It occurred to me that this could be used to test Andes. This PR uses a Docker file based on [rlincoln/oct2pypower](https://hub.docker.com/r/rlincoln/oct2pypower) to encapsulate all of the dependencies. Only a simple test that compares bus voltages has been added, but this could be extended. The container image is built and run in the usual way:

```
$ docker build -f matpower.dockerfile -t andes .
$ docker run -it --rm andes
```

This should be a good way to ensure pflow in Andes is consistent with MATPOWER across all test cases. Perhaps it could be integrated into the CI configuration.