### PR TITLE
REECA1 fix

### DIFF
--- a/andes/models/governor/hygov.py
+++ b/andes/models/governor/hygov.py
@@ -123,6 +123,9 @@ class HYGOVModel(TGBase):
     Implement HYGOV model.
 
     The input lead-lag filter is ignored.
+
+    The g (LAG) is initialized at q (Integrator) initial value to
+    simplify the initializaiton equations.
     """
 
     def __init__(self, system, config):

--- a/andes/models/governor/hygov.py
+++ b/andes/models/governor/hygov.py
@@ -1,3 +1,7 @@
+"""
+HYGOV hydro governor model.
+"""
+
 from andes.core import Algeb, ConstService, NumParam, State
 from andes.core.block import Integrator, Lag, DeadBand1, AntiWindupRate
 from andes.core.service import VarService
@@ -124,8 +128,8 @@ class HYGOVModel(TGBase):
 
     The input lead-lag filter is ignored.
 
-    The g (LAG) is initialized at q (Integrator) initial value to
-    simplify the initializaiton equations.
+    The ``g`` signal (LAG) is initialized to the initial value of
+    ``q`` (Integrator) to simplify the initializaiton equations.
     """
 
     def __init__(self, system, config):

--- a/andes/models/renewable/reeca1.py
+++ b/andes/models/renewable/reeca1.py
@@ -332,7 +332,7 @@ class REECA1Model(Model):
 
         self.Iqcmd = ExtAlgeb(model='RenGen', src='Iqcmd', indexer=self.reg, export=False,
                               info='Retrieved Iqcmd of RenGen',
-                              e_str='-Iqcmd0 - IqHL_y',
+                              e_str='-Iqcmd0 + IqHL_y',
                               )
 
         self.p0 = ExtService(model='RenGen',

--- a/andes/models/renewable/reeca1.py
+++ b/andes/models/renewable/reeca1.py
@@ -394,22 +394,21 @@ class REECA1Model(Model):
         self.S1 = Lag(u='Pe', T=self.Tp, K=1, tex_name='S_1', info='Pe filter',
                       )
 
+        self.qref0 = ConstService(tex_name='q_{ref0}')
+        self.qref0.v_str = 'SWQ_s1 * (v - Vref1) + SWQ_s0 * Iqcmd0 * (v * VLower_zi + 0.01 * VLower_zl)'
+        self.Qref = Algeb(tex_name='Q_{ref}',
+                          info='external Q ref',
+                          v_str='qref0',
+                          e_str='qref0 - Qref',
+                          unit='p.u.',
+                          )
+
         # ignore `Qcpf` if `pfaref` is pi/2 by multiplying (1-zp0)
         self.Qcpf = Algeb(tex_name='Q_{cpf}',
                           info='Q calculated from P and power factor',
                           v_str='q0',
                           e_str='(1-zp0) * (S1_y * tan(pfaref) - Qcpf)',
                           diag_eps=True,
-                          unit='p.u.',
-                          )
-
-        self.qref0 = ConstService(v_str='v - Vref1',
-                                  tex_name='q_{ref0}',
-                                  )
-        self.Qref = Algeb(tex_name='Q_{ref}',
-                          info='external Q ref',
-                          v_str='qref0',
-                          e_str='qref0 - Qref',
                           unit='p.u.',
                           )
 
@@ -445,7 +444,8 @@ class REECA1Model(Model):
                           e_str='(PFsel + SWQ_s0 * (Iqcmd0 * vp - PFsel)) / vp - s4in',
                           tex_name='s_{4in}',
                           )
-        self.s4 = LagFreeze(u=self.s4in, T=self.Tiq, K=1,
+        self.s4 = LagFreeze(u='PFsel / vp',
+                            T=self.Tiq, K=1,
                             freeze=self.Volt_dip,
                             tex_name='s_4',
                             info='Filter for calculated voltage with freeze',
@@ -648,7 +648,7 @@ class REECA1Model(Model):
                                   info='Lower limit on Ipcmd',
                                   )
 
-        self.PIV = PITrackAWFreeze(u='Vsel_y - s0_y * SWV_s0',
+        self.PIV = PITrackAWFreeze(u='SWQ_s1 * (Vsel_y - s0_y * SWV_s0)',
                                    x0='-SWQ_s1 * Iqcmd0',
                                    kp=self.Kvp, ki=self.Kvi, ks=self.config.kvs,
                                    lower=self.Iqmin, upper=self.Iqmax,


### PR DESCRIPTION
![debug_REECA1](https://user-images.githubusercontent.com/79226045/146614325-a49094f9-1d0f-4b82-ab5e-58f5a7cc562b.png)


No. 1
When SWV_s0 = 1, SWPF_s0 =1, 
PIV_input = Vref1 + Qref – Vt, which should be 0, so I fixed the equations of Qref.

No. 2
Also, when SWPF_s0 =1, it means PIQ is out of use, I fixed its input equation to make sure it is 0.
The input equation of PIQ is changed to make sure the input is 0.

No. 3
When SWQ_s0 = 1, SWPF_s0 =1,
S4_input = PFsel / vp, which should be Iqcmd0. However, the Qref is set by PIV, so I add an additional constant value in s4_input.