### PR TITLE
Fix bug in pandapower interface

### DIFF
--- a/andes/interop/pandapower.py
+++ b/andes/interop/pandapower.py
@@ -221,7 +221,7 @@ def _to_pp_line(ssa, ssp, ssa_bus):
     ssl = ssa_line
     ssl['uidx'] = ssl.index
     index_line = ssl['uidx'][ssl['Vn1'] == ssl['Vn2']][ssl['trans'] == 0]
-    ll_ka = len(ssa_line) * [99999]  # set large line limits
+    ll_ka = len(ssa_line) * [100]  # set large line limits
 
     ssa_line['name'] = _rename(ssa_line['name'])
     # --- 2a. transmission lines ---
@@ -475,7 +475,7 @@ def to_pandapower(ssa, ctrl=[], verify=True, tol=1e-6):
     -----
     Handling of the following parameters:
 
-      - Line limts are set as 99999.0 in the output network.
+      - Line limts are set as 100.0 in the output network.
       - Generator cost is not included in the conversion. Use ``add_gencost()``
         to add cost data.
       - By default, ``SynGen`` equipped with ``TurbineGov`` in the ANDES System is converted

--- a/andes/interop/pandapower.py
+++ b/andes/interop/pandapower.py
@@ -189,7 +189,7 @@ def add_gencost(ssp, gen_cost):
     return True
 
 
-def to_pp_bus(ssp, ssa_bus):
+def _to_pp_bus(ssp, ssa_bus):
     """Create bus in pandapower net"""
     for uid in ssa_bus.index:
         pp.create_bus(net=ssp,
@@ -204,7 +204,7 @@ def to_pp_bus(ssp, ssa_bus):
     return ssp
 
 
-def to_pp_line(ssa, ssp, ssa_bus):
+def _to_pp_line(ssa, ssp, ssa_bus):
     """Create line in pandapower net"""
     # TODO: 1) from- and to- sides `Y`; 2)`g`
     omega = 2 * pi * ssp.f_hz
@@ -298,7 +298,7 @@ def to_pp_line(ssa, ssp, ssa_bus):
     return ssp
 
 
-def to_pp_load(ssa, ssp, ssa_bus):
+def _to_pp_load(ssa, ssp, ssa_bus):
     """Create load in pandapower net"""
     ssa_pq = ssa.PQ.as_df()
     ssa_pq['p_mw'] = ssa_pq["p0"] * ssp.sn_mva
@@ -322,7 +322,7 @@ def to_pp_load(ssa, ssp, ssa_bus):
     return ssp
 
 
-def to_pp_shunt(ssa, ssp, ssa_bus):
+def _to_pp_shunt(ssa, ssp, ssa_bus):
     """Create shunt in pandapower net"""
     ssa_shunt = ssa.Shunt.as_df()
     ssa_shunt['p_mw'] = ssa_shunt["g"] * ssp.sn_mva
@@ -346,7 +346,7 @@ def to_pp_shunt(ssa, ssp, ssa_bus):
     return ssp
 
 
-def to_pp_gen_pre(ssa):
+def _to_pp_gen_pre(ssa):
     """Create generator data in pandapower net"""
     # build StaticGen df
     stg_cols = ['idx', 'u', 'name', 'bus', 'v0', 'vmax', 'vmin']
@@ -399,10 +399,10 @@ def to_pp_gen_pre(ssa):
         return ssa_sg
 
 
-def to_pp_gen(ssa, ssp, ctrl=[]):
+def _to_pp_gen(ssa, ssp, ctrl=[]):
     """Create shunt in pandapower net"""
     # TODO: Add RenGen
-    ssa_sg = to_pp_gen_pre(ssa)
+    ssa_sg = _to_pp_gen_pre(ssa)
 
     # assign slack bus
     ssa_sg["slack"] = False
@@ -411,7 +411,7 @@ def to_pp_gen(ssa, ssp, ctrl=[]):
     # compute the actual value
     stg_calc_cols = ['p0', 'q0', 'pmax', 'pmin', 'qmax', 'qmin']
     ssa_sg[stg_calc_cols] = ssa_sg[stg_calc_cols].apply(lambda x: x * ssp.sn_mva)
-    if 'gammap' not in to_pp_gen_pre(ssa).columns:
+    if 'gammap' not in _to_pp_gen_pre(ssa).columns:
         ssa_sg['gammap'] = 1
         ssa_sg['gammaq'] = 1
     else:
@@ -502,19 +502,19 @@ def to_pandapower(ssa, ctrl=[], verify=True, tol=1e-6):
     ssa_bus['name'] = _rename(ssa_bus['name'])
 
     # --- 1. convert buses ---
-    ssp = to_pp_bus(ssp, ssa_bus)
+    ssp = _to_pp_bus(ssp, ssa_bus)
 
     # --- 2. convert Line ---
-    ssp = to_pp_line(ssa, ssp, ssa_bus)
+    ssp = _to_pp_line(ssa, ssp, ssa_bus)
 
     # --- 3. load ---
-    ssp = to_pp_load(ssa, ssp, ssa_bus)
+    ssp = _to_pp_load(ssa, ssp, ssa_bus)
 
     # --- 4. shunt ---
-    ssp = to_pp_shunt(ssa, ssp, ssa_bus)
+    ssp = _to_pp_shunt(ssa, ssp, ssa_bus)
 
     # --- 5. generator ---
-    ssp = to_pp_gen(ssa, ssp, ctrl)
+    ssp = _to_pp_gen(ssa, ssp, ctrl)
 
     if verify:
         _verify_pf(ssa, ssp, tol)

--- a/andes/interop/pandapower.py
+++ b/andes/interop/pandapower.py
@@ -396,7 +396,7 @@ def to_pp_gen_pre(ssa):
     return ssa_sg
 
 
-def to_pp_gen(ssa, ssp, ctrl):
+def to_pp_gen(ssa, ssp, ctrl=[]):
     """Create shunt in pandapower net"""
     # TODO: Add RenGen
     ssa_sg = to_pp_gen_pre(ssa)

--- a/andes/interop/pandapower.py
+++ b/andes/interop/pandapower.py
@@ -142,13 +142,11 @@ def runopp_map(ssp, link_table, **kwargs):
                        right=ssp.bus[['name']].reset_index().rename(
                            columns={'index': 'bus', 'name': 'bus_name'}),
                        how='left', on='bus')
-    ssp_res['p'] = ssp_res['p_mw'] / ssp.sn_mva
-    ssp_res['q'] = ssp_res['q_mvar'] / ssp.sn_mva
     ssp_res = pd.merge(left=ssp_res,
                        right=link_table,
                        how='left', on='bus_name')
-    ssp_res['p'] = ssp_res['p_mw'] * ssp_res['gammap']
-    ssp_res['q'] = ssp_res['q_mvar'] * ssp_res['gammaq']
+    ssp_res['p'] = ssp_res['p_mw'] * ssp_res['gammap'] / ssp.sn_mva
+    ssp_res['q'] = ssp_res['q_mvar'] * ssp_res['gammaq'] / ssp.sn_mva
     col = ['name', 'p', 'q', 'vm_pu', 'bus_name', 'bus_idx',
            'controllable', 'dg_idx', 'syg_idx', 'gov_idx', 'exc_idx', 'stg_idx']
     return ssp_res[col]

--- a/andes/interop/pandapower.py
+++ b/andes/interop/pandapower.py
@@ -346,7 +346,6 @@ def to_pp_shunt(ssa, ssp, ssa_bus):
     return ssp
 
 
-# --- debug ---
 def to_pp_gen_pre(ssa):
     """Create generator data in pandapower net"""
     # build StaticGen df
@@ -425,10 +424,13 @@ def to_pp_gen(ssa, ssp, ctrl=[]):
             raise ValueError("ctrl length does not match StaticGen length")
         ssa_sg["ctrl"] = [bool(x) for x in ctrl]
     else:
-        if make_link_table(ssa)["gov_idx"].shape[0] == 0:
+        key = make_link_table(ssa)
+        if key.shape[0] == 0:
+            # if no dyn device, set all generators as controllable
             ssa_sg["ctrl"] = [bool(x) for x in [1]*len(ssa_sg)]
         else:
-            ssa_sg["ctrl"] = [not x for x in make_link_table(ssa)["gov_idx"].drop_duplicates().isna()]
+            key = key[~key['stg_idx'].duplicated()]
+            ssa_sg["ctrl"] = [bool(x) for x in key['gov_idx']]
 
     ssa_sg['name'] = _rename(ssa_sg['name'])
     # conversion

--- a/andes/interop/pandapower.py
+++ b/andes/interop/pandapower.py
@@ -17,6 +17,34 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
+def build_group_table(ssa, group, columns):
+    """
+    Build the table for devices in a group in an ADNES System.
+
+    Parameters
+    ----------
+    ssa :
+        The ADNES system to build the table
+    group : string
+        The ADNES group
+    columns : list of string
+        The common columns of a group that to be included in the table.
+
+    Returns
+    -------
+    DataFrame
+
+        The output Dataframe contains the columns from the device
+    """
+    group_df = pd.DataFrame(columns=columns)
+    group = getattr(ssa, group)
+    mdl_dict = getattr(group, 'models')
+    for key in mdl_dict:
+        mdl = getattr(ssa, key)
+        group_df = pd.concat([group_df, mdl.as_df()[columns]], axis=0)
+    return group_df
+
+
 def make_link_table(ssa):
     """
     Build the link table for generators and generator controllers in an ADNES
@@ -35,11 +63,7 @@ def make_link_table(ssa):
         ``StaticGen``, ``Bus``, ``SynGen``, ``Exciter``, and ``TurbineGov``.
     """
     # build StaticGen df
-    sg_cols = ['name', 'idx', 'bus']
-    ssa_sg = pd.DataFrame(columns=sg_cols)
-    for key in ssa.StaticGen.models:
-        sg = getattr(ssa, key)
-        ssa_sg = pd.concat([ssa_sg, sg.as_df()[sg_cols]], axis=0)
+    ssa_sg = build_group_table(ssa, 'StaticGen', ['name', 'idx', 'bus'])
     # build TurbineGov df
     gov_cols = ['idx', 'syn']
     ssa_gov = pd.DataFrame(columns=gov_cols)

--- a/andes/interop/pandapower.py
+++ b/andes/interop/pandapower.py
@@ -23,7 +23,7 @@ def build_group_table(ssa, group, columns, mdl_name=[]):
 
     Parameters
     ----------
-    ssa :
+    ssa : andes.system.System
         The ADNES system to build the table
     group : string
         The ADNES group
@@ -59,7 +59,7 @@ def make_link_table(ssa):
 
     Parameters
     ----------
-    ssa :
+    ssa : andes.system.System
         The ADNES system to link
 
     Returns

--- a/andes/interop/pandapower.py
+++ b/andes/interop/pandapower.py
@@ -76,9 +76,9 @@ def make_link_table(ssa):
     # build Exciter df
     ssa_exc = build_group_table(ssa, 'Exciter', ['idx', 'syn'])
     # build SynGen df
-    ssa_syg = build_group_table(ssa, 'SynGen', ['idx', 'bus', 'gen'])
+    ssa_syg = build_group_table(ssa, 'SynGen', ['idx', 'bus', 'gen', 'gammap', 'gammaq'], ['GENCLS', 'GENROU'])
     # build DG df
-    ssa_dg = build_group_table(ssa, 'DG', ['idx', 'bus', 'gen'])
+    ssa_dg = build_group_table(ssa, 'DG', ['idx', 'bus', 'gen', 'gammap', 'gammaq'])
 
     # output
     ssa_bus = ssa.Bus.as_df()[['name', 'idx']]
@@ -97,7 +97,7 @@ def make_link_table(ssa):
     ssa_key = pd.merge(left=ssa_key,
                        right=ssa_gov.rename(columns={'idx': 'gov_idx', 'syn': 'syg_idx'}),
                        how='left', on='syg_idx')
-    cols = ['stg_name', 'stg_idx', 'bus_idx', 'syg_idx', 'exc_idx', 'gov_idx', 'bus_name']
+    cols = ['stg_name', 'stg_idx', 'bus_idx', 'syg_idx', 'exc_idx', 'gov_idx', 'bus_name', 'gammap', 'gammaq']
     return ssa_key[cols]
 
 

--- a/andes/interop/pandapower.py
+++ b/andes/interop/pandapower.py
@@ -430,7 +430,7 @@ def _to_pp_gen(ssa, ssp, ctrl=[]):
             ssa_sg["ctrl"] = [bool(x) for x in [1]*len(ssa_sg)]
         else:
             key = key[~key['stg_idx'].duplicated()]
-            ssa_sg["ctrl"] = [bool(x) for x in key['gov_idx']]
+            ssa_sg["ctrl"] = [bool(x) for x in key['gov_idx'].fillna(False)]
 
     ssa_sg['name'] = _rename(ssa_sg['name'])
     # conversion

--- a/tests/test_pandapower.py
+++ b/tests/test_pandapower.py
@@ -22,35 +22,25 @@ class TestPandapower(unittest.TestCase):
     Tests for the ANDES-pandapower interface.
     """
 
+    cases = ['ieee14/ieee14_ieeet1.xlsx',
+             'ieee14/ieee14_pvd1.xlsx',
+             'ieee39/ieee39.xlsx',
+             'npcc/npcc.xlsx',
+             ]
+
     def setUp(self) -> None:
         """
         Test setup. This is executed before each test case.
         """
-        pass
 
-    def test_to_pandapower_ieee14(self):
+    def test_to_pandapower(self):
         """
-        Test `andes.interop.pandapower.to_pandapower` with ieee14
+        Test `andes.interop.pandapower.to_pandapower` with cases
         """
+        for case_file in self.cases:
+            case = andes.get_case(case_file)
 
-        case14 = andes.get_case('ieee14/ieee14_ieeet1.xlsx')
-        return test_to_pandapower_single(case14, tol=1e-7)
-
-    def test_to_pandapower_ieee39(self):
-        """
-        Test `andes.interop.pandapower.to_pandapower` with ieee39
-        """
-
-        case39 = andes.get_case('ieee39/ieee39.xlsx')
-        return test_to_pandapower_single(case39, tol=1e-6)
-
-    def test_to_pandapower_wecc(self):
-        """
-        Test `andes.interop.pandapower.to_pandapower` with wecc
-        """
-
-        case_wecc = andes.get_case('wecc/wecc_full.xlsx')
-        return test_to_pandapower_single(case_wecc, tol=1e-5)
+        test_to_pandapower_single(case, tol=1e-3)
 
     def test_make_link_table(self):
         """
@@ -62,7 +52,7 @@ class TestPandapower(unittest.TestCase):
                           no_output=True,
                           default_config=True)
         link_table = make_link_table(sa14)
-        ridx = link_table[link_table['syn_idx'] == 'GENROU_1'].index
+        ridx = link_table[link_table['syg_idx'] == 'GENROU_1'].index
         c_bus = link_table['bus_name'].iloc[ridx].astype(str) == 'BUS1'
         c_exc = link_table['exc_idx'].iloc[ridx].astype(str) == 'ESST3A_2'
         c_stg = link_table['stg_idx'].iloc[ridx].astype(str) == '1'
@@ -91,4 +81,4 @@ def test_to_pandapower_single(case, **kwargs):
     rid_slack = np.argmin(np.abs(a_pp))
     a_andes = a_andes - a_andes[rid_slack]
 
-    return np.testing.assert_almost_equal(v_andes, v_pp, decimal=5)
+    return np.testing.assert_almost_equal(v_andes, v_pp, decimal=3)

--- a/tests/test_pandapower.py
+++ b/tests/test_pandapower.py
@@ -6,7 +6,7 @@ import unittest
 import numpy as np
 
 import andes
-from andes.shared import rad2deg
+from andes.shared import deg2rad
 from andes.interop.pandapower import to_pandapower, make_link_table
 
 try:
@@ -26,41 +26,69 @@ class TestPandapower(unittest.TestCase):
         """
         Test setup. This is executed before each test case.
         """
+        pass
 
-        ssa = andes.load(andes.get_case('ieee14/ieee14_ieeet1.xlsx'),
-                         setup=True,
-                         no_output=True,
-                         default_config=True)
-        ssp = to_pandapower(ssa)
-
-        ssa.PFlow.run()
-        pp.runpp(ssp)
-
-        self.v_andes = ssa.Bus.v.v
-        self.a_andes = ssa.Bus.a.v * rad2deg
-
-        self.v_pp = ssp.res_bus['vm_pu']
-        self.a_pp = ssp.res_bus['va_degree']
-
-        self.link_table = make_link_table(ssa)
-
-    def test_to_pandapower(self):
+    def test_to_pandapower_ieee14(self):
         """
-        Test `andes.interop.pandapower.to_pandapower`
+        Test `andes.interop.pandapower.to_pandapower` with ieee14
         """
 
-        np.testing.assert_almost_equal(self.v_andes, self.v_pp, decimal=6)
-        np.testing.assert_almost_equal(self.a_andes, self.a_pp, decimal=6)
+        case14 = andes.get_case('ieee14/ieee14_ieeet1.xlsx')
+        return test_to_pandapower_single(case14, tol=1e-7)
+
+    def test_to_pandapower_ieee39(self):
+        """
+        Test `andes.interop.pandapower.to_pandapower` with ieee39
+        """
+
+        case39 = andes.get_case('ieee39/ieee39.xlsx')
+        return test_to_pandapower_single(case39, tol=1e-6)
+
+    def test_to_pandapower_wecc(self):
+        """
+        Test `andes.interop.pandapower.to_pandapower` with wecc
+        """
+
+        case_wecc = andes.get_case('wecc/wecc_full.xlsx')
+        return test_to_pandapower_single(case_wecc, tol=1e-5)
 
     def test_make_link_table(self):
         """
         Test `andes.interop.pandapower.make_link_table`
         """
 
-        ridx = self.link_table[self.link_table['syn_idx'] == 'GENROU_1'].index
-        c_bus = self.link_table['bus_name'].iloc[ridx].astype(str) == 'BUS1'
-        c_exc = self.link_table['exc_idx'].iloc[ridx].astype(str) == 'ESST3A_2'
-        c_stg = self.link_table['stg_idx'].iloc[ridx].astype(str) == '1'
-        c_gov = self.link_table['gov_idx'].iloc[ridx].astype(str) == 'TGOV1_1'
+        sa14 = andes.load(andes.get_case('ieee14/ieee14_ieeet1.xlsx'),
+                          setup=True,
+                          no_output=True,
+                          default_config=True)
+        link_table = make_link_table(sa14)
+        ridx = link_table[link_table['syn_idx'] == 'GENROU_1'].index
+        c_bus = link_table['bus_name'].iloc[ridx].astype(str) == 'BUS1'
+        c_exc = link_table['exc_idx'].iloc[ridx].astype(str) == 'ESST3A_2'
+        c_stg = link_table['stg_idx'].iloc[ridx].astype(str) == '1'
+        c_gov = link_table['gov_idx'].iloc[ridx].astype(str) == 'TGOV1_1'
         c = c_bus.values[0] and c_exc.values[0] and c_stg.values[0] and c_gov.values[0]
         return c
+
+
+def test_to_pandapower_single(case, **kwargs):
+    """
+    Test `andes.interop.pandapower.to_pandapower` with a single case
+    """
+
+    sa = andes.load(case, setup=True, no_output=True, default_config=True)
+    sp = to_pandapower(sa, **kwargs)
+
+    sa.PFlow.run()
+    pp.runpp(sp)
+
+    v_andes = sa.Bus.v.v
+    a_andes = sa.Bus.a.v
+    v_pp = sp.res_bus['vm_pu']
+    a_pp = sp.res_bus['va_degree'] * deg2rad
+
+    # align ssa angle with slcka bus angle
+    rid_slack = np.argmin(np.abs(a_pp))
+    a_andes = a_andes - a_andes[rid_slack]
+
+    return np.testing.assert_almost_equal(v_andes, v_pp, decimal=5)

--- a/tests/test_pandapower.py
+++ b/tests/test_pandapower.py
@@ -40,7 +40,7 @@ class TestPandapower(unittest.TestCase):
         for case_file in self.cases:
             case = andes.get_case(case_file)
 
-        test_to_pandapower_single(case, tol=1e-3)
+            _test_to_pandapower_single(case, tol=1e-3)
 
     def test_make_link_table(self):
         """
@@ -61,7 +61,7 @@ class TestPandapower(unittest.TestCase):
         return c
 
 
-def test_to_pandapower_single(case, **kwargs):
+def _test_to_pandapower_single(case, **kwargs):
     """
     Test `andes.interop.pandapower.to_pandapower` with a single case
     """


### PR DESCRIPTION
Fix bug in pandapower interface:
1) ``to_pandapower``
    1) fix the bug of device_mva when creating generator
    1) auto rename device if duplicates of names exist
    1) verification: a) align bus angle with slack bus, b) add user-defined tolerance
    1) refactor ``to_pandapower`` with multiple sub-functions
    1) refactor ``to_pandapower`` with multiple conditions: a) no dynamic devices, b) one ``StaticGen`` to many ``SynGen`` or ``DG``
1) ``make_link_table``: refactor ``make_link_table`` with new sub-functions
1) ``test_pandapower``: refactor test with multiple cases
1) ``runopp_map``: include ``DG`` in the results
