### PR TITLE
Revision of pandapower interface

### DIFF
--- a/andes/interop/pandapower.py
+++ b/andes/interop/pandapower.py
@@ -633,7 +633,7 @@ def _verifyGSF(ppn, gsf, tol=1e-4):
     rl_c = np.array(np.matrix(gsf) * np.matrix(rp.ngen).T)
     res_gap = rl.p_from_mw.values - rl_c.flatten()
     if np.abs(res_gap).max() <= tol:
-        logger.info("GSF is consisstent.")
+        logger.info("GSF is consistent.")
     else:
         logger.warning("Warning: GSF is inconsistent. Pleaes check!")
 
@@ -648,4 +648,6 @@ def _sumPF_ppn(ppn):
     rp = rp.merge(rd, on='bus', how='left')
     rp.fillna(0, inplace=True)
     rp['ngen'] = rp['gen'] - rp['demand']
+    rp = rp.groupby('bus').sum().reset_index(drop=True)
+    rp['bus'] = rp.index
     return rp

--- a/tests/test_pandapower.py
+++ b/tests/test_pandapower.py
@@ -7,7 +7,7 @@ import numpy as np
 
 import andes
 from andes.shared import deg2rad
-from andes.interop.pandapower import to_pandapower, make_link_table
+from andes.interop.pandapower import to_pandapower, make_link_table, make_GSF
 
 try:
     import pandapower as pp
@@ -60,6 +60,19 @@ class TestPandapower(unittest.TestCase):
         c_gov = link_table['gov_idx'].iloc[ridx].astype(str) == 'TGOV1_1'
         c = c_bus.values[0] and c_exc.values[0] and c_stg.values[0] and c_gov.values[0]
         return c
+
+    def test_make_GSF(self):
+        """
+        Test `andes.interop.pandapower.make_GSF with ieee39`
+        """
+
+        sa39 = andes.load(andes.get_case('ieee39/ieee39.xlsx'),
+                          setup=True,
+                          no_output=True,
+                          default_config=True)
+        sp39 = to_pandapower(sa39)
+        make_GSF(sp39)
+        return True
 
 
 def _test_to_pandapower_single(case, **kwargs):


### PR DESCRIPTION
- Fix ``make_GSF`` in the pandapower interface
- Add test of ``make_GSF``
- Revise ``to_pandapower``: 1) all generators are set to be controllable by default, 2) generators' name in ``ssp`` are given by ``StaticGen.idx``, so that the ``runopp_map`` can use ``stg_idx`` as unique keys