### PR TITLE
Fix pandapower add_gencost

### DIFF
--- a/andes/interop/pandapower.py
+++ b/andes/interop/pandapower.py
@@ -184,10 +184,10 @@ def add_gencost(ssp, gen_cost):
     """
 
     # check dimension
-    if gen_cost.shape[0] != ssp.gen[ssp.gen['controllable']].shape[0]:
-        print('Input cost function size does not match controllable gen size.')
+    if gen_cost.shape[0] != ssp.gen.shape[0]:
+        print('Input cost function size does not match gen size.')
 
-    for num, uid in enumerate(ssp.gen[ssp.gen['controllable']].index):
+    for num, uid in enumerate(ssp.gen.index):
         if gen_cost[num, 0] == 2:  # poly_cost
             pp.create_poly_cost(net=ssp,
                                 element=uid,

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -29,6 +29,10 @@ Operator splitting for internal algebraic variables:
 - ``VarService`` takes an argument ``sequential``, which is ``True`` by default.
   Non-sequential ``VarService`` shall not depend on other ``VarService``
   calculated at the same step as they will be evaluated simultaneously.
+- ``to_pandapower()`` set all generators as controllable by default, the name
+  of generators in converted pandapower case are named with the ``idx`` of
+  ``StaticGen``.
+- Bug fixes of ``make_link_table``.
 
 Other changes:
 


### PR DESCRIPTION
Change ``add_gencost`` to work on all generators rather than controllable ones, which will be easier to use if there are uncontrollable generators that will participate in scheduling later